### PR TITLE
Fix: sink layer id and tensor write-back scheduling

### DIFF
--- a/stream/cost_model/scheduler.py
+++ b/stream/cost_model/scheduler.py
@@ -558,6 +558,7 @@ class CoalaScheduler:
                 tensor=tensor_to_remove,
                 receiving_core=self.offchip_core,
                 tensor_operand=memory_op,
+                earliest_t=timestep,
                 sending_core=core_to_remove_from,
                 transfer_bandwidth_fraction=transfer_bandwidth_fraction,
                 transfer_cause=transfer_cause,

--- a/stream/workload/onnx_workload.py
+++ b/stream/workload/onnx_workload.py
@@ -64,18 +64,12 @@ class ComputationNodeWorkload(DiGraphWrapper[ComputationNode]):
 
     def get_sink_layer_ids(self):
         """Return the ids of layers where ALL sub-nodes have out-degree 0
-        # TODO this might nog work yet! When there is intra-core tiling, edges between nodes in the same layer
-        # TODO (with bits==0) are added, meaning some nodes have an out-degree > 0
-        # TODO -> use get_real_nb_predecessors instead? or remove the empty intra-core edges?
+        # Finding 1 node with no outgoing edges is sufficient
+        # This implies that all nodes with same layer id are output nodes
+        # other nodes might have edges due to intra-layer cuts
         """
         out_degrees = self.out_degree()
-        layer_ids = set(n.id for n, _ in out_degrees)
-        sink_layer_ids = [
-            curr_id
-            for curr_id in layer_ids
-            # x: (node, out_degree). Filter by id -> map to out_degree == 0 -> check if all are 0
-            if all(map(lambda x: x[1] == 0, filter(lambda x: x[0].id == curr_id, out_degrees)))
-        ]
+        sink_layer_ids = set(n.id for n, out_degree in out_degrees if out_degree == 0)
         return sink_layer_ids
 
     def get_subgraph(self, nodes: list[ComputationNode]) -> "ComputationNodeWorkload":


### PR DESCRIPTION
I created this fix for sink layer ids. The logic is as follows:

Current implementation looks for layer ids where ALL nodes associated with id have no successors. This is wrong, as intra-layer partitioning leads to edges between sink nodes. Instead, if ONE node with a certain id has no successor, then ALL nodes with that id should be considered as sink nodes.

EDIT: I have added a second bug fix related to scheduling tensor write-back. Without this fix, a tensor write-back may overlap with another tensor transfer (from off-chip to a core). I wanted to do this in a more proper way with two separate pull request, but I have realized my mistake too late. Hence, I combined both fixes in this pull request. (Sorry)
Please review each commit separately and decide if any or both are acceptable