### PR TITLE
Simplify tensor priority

### DIFF
--- a/stream/cost_model/memory_manager.py
+++ b/stream/cost_model/memory_manager.py
@@ -215,7 +215,7 @@ class MemoryManager:
         evictable_tensors = [tensor for tensor in stored_tensors if tensor not in relevant_exceptions]
         evictable_tensors_priority_size: list[int] = []
         for tensor in evictable_tensors:
-            instance_priority = tensor.get_instance_priority()
+            instance_priority = tensor.get_tensor_priority()
             importance = instance_priority * tensor.size
             evictable_tensors_priority_size.append(importance)
         evictable_tensors_priority_size_tuple, evictable_tensors_tuple = zip(

--- a/stream/cost_model/memory_manager.py
+++ b/stream/cost_model/memory_manager.py
@@ -215,7 +215,7 @@ class MemoryManager:
         evictable_tensors = [tensor for tensor in stored_tensors if tensor not in relevant_exceptions]
         evictable_tensors_priority_size: list[int] = []
         for tensor in evictable_tensors:
-            instance_priority = tensor.get_instance_priority(top_instance, self)
+            instance_priority = tensor.get_instance_priority()
             importance = instance_priority * tensor.size
             evictable_tensors_priority_size.append(importance)
         evictable_tensors_priority_size_tuple, evictable_tensors_tuple = zip(

--- a/stream/cost_model/scheduler.py
+++ b/stream/cost_model/scheduler.py
@@ -123,7 +123,7 @@ class CoalaScheduler:
         """
         for n in self.G.node_list:
             for tensor in n.operand_tensors.values():
-                tensor.initialize_instance_priorities(self.G, n, self.accelerator)
+                tensor.initialize_tensor_priority(self.G, n)
 
     def initialize_offchip_tensors(self):
         """
@@ -747,7 +747,7 @@ class CoalaScheduler:
         for tensor_used_by_node in tensors:
             # TODO: tensor_memory_operand will be 'O' for activation tensors.
             # TODO: If the memory between input and output is not shared, this will give a wrong instance.
-            tensor_used_by_node.instance_priority -= 1
+            tensor_used_by_node.decrement_tensor_priority()
 
     def check_for_removal(
         self,
@@ -757,7 +757,7 @@ class CoalaScheduler:
     ):
         """Remove the tensor from the core if its priority is zero."""
         for tensor_used_by_node in tensors:
-            if tensor_used_by_node.get_instance_priority() == 0:
+            if tensor_used_by_node.get_tensor_priority() == 0:
                 instances_storing_tensor, _ = self.accelerator.memory_manager.find_tensor_in_top_instances(
                     tensor_used_by_node
                 )

--- a/stream/hardware/architecture/accelerator.py
+++ b/stream/hardware/architecture/accelerator.py
@@ -253,8 +253,7 @@ class Accelerator:
         # Remove from sending core (except if it is offchip)
         if sending_core.id != self.offchip_core_id:
             not_on_producing_core = sending_core.id != tensor.origin.chosen_core_allocation
-            storing_instance = self.get_storing_memory_instance(tensor, sending_core)
-            tensor_priority = tensor.get_instance_priority(storing_instance, self.memory_manager)
+            tensor_priority = tensor.get_instance_priority()
             if not_on_producing_core and tensor_priority == 0:
                 self.remove_tensor(tensor, sending_core, memory_op=tensor.memory_operand, timestep=transfer_end)
 

--- a/stream/hardware/architecture/accelerator.py
+++ b/stream/hardware/architecture/accelerator.py
@@ -253,7 +253,7 @@ class Accelerator:
         # Remove from sending core (except if it is offchip)
         if sending_core.id != self.offchip_core_id:
             not_on_producing_core = sending_core.id != tensor.origin.chosen_core_allocation
-            tensor_priority = tensor.get_instance_priority()
+            tensor_priority = tensor.get_tensor_priority()
             if not_on_producing_core and tensor_priority == 0:
                 self.remove_tensor(tensor, sending_core, memory_op=tensor.memory_operand, timestep=transfer_end)
 


### PR DESCRIPTION
I see no reason for assigning tensor priorities per top memory instance. In my opinion, this adds layers of unnecessary complexity and OOP referencing spaghetti. To me, a tensor's priority should be a global variable that depends on how many times the tensor has been used or will be used by any node mapped to any core.

This change simplifies the tensor priority API from a [top instance: int] dictionary to a simple int.