### PR TITLE
feat(aie): mapping-driven two-fusion-group SwiGLU codegen

### DIFF
--- a/stream/api.py
+++ b/stream/api.py
@@ -5,7 +5,7 @@ from typing import Any
 import yaml
 from onnx import ModelProto
 from zigzag.mapping.temporal_mapping import TemporalMappingType
-from zigzag.utils import pickle_load
+from zigzag.utils import open_yaml, pickle_load
 
 from stream.opt.solver import ConstraintSelection, GurobiBackend, SolverBackend
 from stream.stages.allocation.constraint_optimization_allocation import ConstraintOptimizationAllocationStage
@@ -111,7 +111,32 @@ def optimize_allocation_co_with_mapping(  # noqa: PLR0913
         if enable_codegen:
             from stream.stages.codegen.aie_code_generation import AIECodeGenerationStage  # noqa: PLC0415
 
-            stages = [AIECodeGenerationStage] + stages
+            n_fused_groups = len(open_yaml(mapping)["fused_groups"]) if isinstance(mapping, str) else 1
+            if n_fused_groups > 1:
+                # Multi-group fixed mapping: split the workload at the mapping's
+                # fused-group boundaries and run the allocation + codegen inner
+                # pipeline once per group, writing each group's MLIR under
+                # <output_path>/group_i/. Mirrors the generic multi-group pipeline
+                # but driven by the hand-written (fixed) mapping.
+                from stream.stages.generation.fixed_mapping_generation import (  # noqa: PLC0415
+                    FixedMappingGenerationStage,
+                )
+
+                stages = [
+                    AcceleratorParserStage,
+                    StreamONNXModelParserStage,
+                    FixedMappingGenerationStage,  # split workload + build per-group mappings (in-memory)
+                    FusionGroupIterationStage,  # outer loop over groups; sets the per-group mapping
+                    AIECodeGenerationStage,  # codegen each group (inner pipeline)
+                    # No MappingParserStage: FixedMappingGenerationStage supplies the
+                    # per-group Mapping objects in-memory via FusionGroupIterationStage.
+                    TilingGenerationStage,
+                    CoreCostEstimationStage,
+                    ConstraintOptimizationAllocationStage,
+                    MemoryAccessesEstimationStage,
+                ]
+            else:
+                stages = [AIECodeGenerationStage] + stages
             ctx.set(
                 npu=npu,  # required by AIECodeGenerationStage
             )

--- a/stream/inputs/aie/mapping/make_swiglu_mapping.py
+++ b/stream/inputs/aie/mapping/make_swiglu_mapping.py
@@ -4,13 +4,27 @@ import os
 import yaml
 
 
-def make_swiglu_mapping(
-    seq_len, embedding_dim, hidden_dim, last_gemm_down, seq_len_tile_size, embedding_tile_size, hidden_tile_size
+def make_swiglu_mapping(  # noqa: PLR0915
+    seq_len,
+    embedding_dim,
+    hidden_dim,
+    last_gemm_down,
+    seq_len_tile_size,
+    embedding_tile_size,
+    hidden_tile_size,
+    split_groups=False,
 ):  # noqa: N803
     """
     This mapping assumes that m rows are computed for each Gemm in a pipelined fashion.
     Each layer is partitioned across four rows of compute tiles with inter_core_tiling in the m dimension
-    It also assumes that line_size columns are computed in a pipelined fashion."""
+    It also assumes that line_size columns are computed in a pipelined fashion.
+
+    When ``split_groups`` is set (requires ``last_gemm_down``), the down-projection
+    Gemm is placed in its own fused group, so the design splits into two fusion
+    groups -- the gate/up/SiLU/mul front end (producing the hidden state) and the
+    down-projection back end -- instead of one fully-fused group. The split is
+    carried purely by the mapping's ``fused_groups``; ``FixedMappingGenerationStage``
+    derives the matching workload cut from it."""
     name = f"swiglu_{seq_len}_{embedding_dim}_{hidden_dim}"
     output_file = os.path.join(os.path.dirname(__file__), f"{name}_v2.yaml")
 
@@ -146,21 +160,48 @@ def make_swiglu_mapping(
             "output": {},
         }
 
-    # Fused groups; Only one group of all operators with Gemm_Left.D0 dimension
-    fused_groups = {
-        "name": "Fused_Group_1",
-        "layers": [layer["name"] for layer in layers],
-        "intra_core_tiling": [
-            {"dim": "Gemm_Left.D1", "tile": INPUT_CHANNEL_TILE_SIZE},
-            {"dim": "Gemm_Left.D2", "tile": OUTPUT_CHANNEL_TILE_SIZE},
-            {"dim": "Gemm_Left.D0", "tile": SEQ_LEN_TILE_SIZE},
-        ],
-    }
-    if last_gemm_down:
-        fused_groups["intra_core_tiling"].insert(1, {"dim": "Gemm_Down.D2", "tile": INPUT_CHANNEL_TILE_SIZE})
+    if split_groups:
+        assert last_gemm_down, "split_groups requires last_gemm_down (nothing to split off otherwise)"
+        # Two fused groups: the gate/up/SiLU/mul front end producing the hidden
+        # state, and the down-projection Gemm consuming it. The front end's
+        # intra-core tiling is expressed on Gemm_Left; the back end's on Gemm_Down
+        # (D1=hidden/contraction, D2=embedding/output, D0=seq).
+        front_group = {
+            "name": "Fused_Group_1",
+            "layers": [gemm_left["name"], gemm_right["name"], silu["name"], mul["name"]],
+            "intra_core_tiling": [
+                {"dim": "Gemm_Left.D1", "tile": INPUT_CHANNEL_TILE_SIZE},
+                {"dim": "Gemm_Left.D2", "tile": OUTPUT_CHANNEL_TILE_SIZE},
+                {"dim": "Gemm_Left.D0", "tile": SEQ_LEN_TILE_SIZE},
+            ],
+        }
+        down_group = {
+            "name": "Fused_Group_2",
+            "layers": [gemm_down["name"]],
+            "intra_core_tiling": [
+                {"dim": "Gemm_Down.D1", "tile": OUTPUT_CHANNEL_TILE_SIZE},
+                {"dim": "Gemm_Down.D2", "tile": INPUT_CHANNEL_TILE_SIZE},
+                {"dim": "Gemm_Down.D0", "tile": SEQ_LEN_TILE_SIZE},
+            ],
+        }
+        fused_groups_list = [front_group, down_group]
+    else:
+        # Fused groups; Only one group of all operators with Gemm_Left.D0 dimension
+        fused_groups = {
+            "name": "Fused_Group_1",
+            "layers": [layer["name"] for layer in layers],
+            "intra_core_tiling": [
+                {"dim": "Gemm_Left.D1", "tile": INPUT_CHANNEL_TILE_SIZE},
+                {"dim": "Gemm_Left.D2", "tile": OUTPUT_CHANNEL_TILE_SIZE},
+                {"dim": "Gemm_Left.D0", "tile": SEQ_LEN_TILE_SIZE},
+            ],
+        }
+        if last_gemm_down:
+            fused_groups["intra_core_tiling"].insert(1, {"dim": "Gemm_Down.D2", "tile": INPUT_CHANNEL_TILE_SIZE})
+        fused_groups_list = [fused_groups]
     mapping = {
         "layers": layers,
-        "fused_groups": [fused_groups],
+        "fused_groups": fused_groups_list,
         "runtime_args": runtime_args,
     }
 

--- a/stream/stages/generation/fixed_mapping_generation.py
+++ b/stream/stages/generation/fixed_mapping_generation.py
@@ -7,7 +7,7 @@ from stream.parser.mapping_factory import MappingFactory
 from stream.parser.mapping_validator import MappingValidator
 from stream.stages.context import StageContext
 from stream.stages.stage import Stage, StageCallable
-from stream.workload.workload import determine_fusion_cut_points
+from stream.workload.workload import InEdge, OutEdge, determine_fusion_cut_points
 
 logger = logging.getLogger(__name__)
 
@@ -33,21 +33,32 @@ class FixedMappingGenerationStage(Stage):
 
     def run(self):
         mapping_data = self._parse_and_validate_yaml()
+        fused_groups_data = mapping_data["fused_groups"]
+
         cut_points = determine_fusion_cut_points(self.workload)
         sub_workloads = self.workload.split_fusion_groups(cut_points=cut_points)
 
-        fused_groups_data = mapping_data["fused_groups"]
+        # A fixed mapping is authoritative about its own grouping. If it declares
+        # a different number of fused groups than the workload heuristic found
+        # (e.g. a SwiGLU split into a gate/up/SiLU/mul group and a separate
+        # down-projection group, which has no MaxPool/residual cut to detect),
+        # derive the cut points from the mapping's group->layer assignment instead.
+        if len(fused_groups_data) != len(sub_workloads):
+            cut_points = self._cut_points_from_fused_groups(fused_groups_data)
+            sub_workloads = self.workload.split_fusion_groups(cut_points=cut_points)
+
         assert len(fused_groups_data) == len(sub_workloads), (
             f"Fixed mapping has {len(fused_groups_data)} fused groups "
             f"but workload splits into {len(sub_workloads)} groups"
         )
 
+        full_runtime_args = mapping_data.get("runtime_args", {})
         sub_mappings = []
         for i, sub_workload in enumerate(sub_workloads):
             per_group_data: dict[str, Any] = {
                 "layers": mapping_data["layers"],
                 "fused_groups": [fused_groups_data[i]],
-                "runtime_args": mapping_data.get("runtime_args", {}),
+                "runtime_args": self._runtime_args_for_group(full_runtime_args, sub_workload),
             }
             factory = MappingFactory(per_group_data, sub_workload, self.accelerator)
             sub_mappings.append(factory.create())
@@ -56,6 +67,33 @@ class FixedMappingGenerationStage(Stage):
         self.ctx.set(sub_workloads=sub_workloads, sub_mappings=sub_mappings)
         sub_stage = self.list_of_callables[0](self.list_of_callables[1:], self.ctx)
         yield from sub_stage.run()
+
+    @staticmethod
+    def _runtime_args_for_group(full_runtime_args: dict[str, Any], sub_workload) -> dict[str, Any]:
+        """Select the runtime args (boundary tensors) belonging to one fusion group.
+
+        A sub-workload's runtime args are its InEdge/OutEdge boundary nodes: model
+        inputs/initializers it consumes, the output(s) it produces, and any
+        inter-group fusion-boundary edge introduced by the split. Explicit layouts
+        from the full mapping are preserved; boundary edges default to the standard
+        (identity) layout via an empty entry.
+        """
+        return {
+            node.name: full_runtime_args.get(node.name, {})
+            for node in sub_workload.nodes
+            if isinstance(node, (InEdge, OutEdge))
+        }
+
+    @staticmethod
+    def _cut_points_from_fused_groups(fused_groups_data: list[dict[str, Any]]) -> list[str]:
+        """Derive workload cut points from a mapping's fused-group layer assignment.
+
+        Cut after the last layer of every group except the last one: that layer
+        produces the tensor consumed by the next group, i.e. the inter-group
+        fusion boundary. ``split_fusion_groups`` keeps the cut-point node in the
+        preceding group, so the boundaries line up with the group definitions.
+        """
+        return [group["layers"][-1] for group in fused_groups_data[:-1]]
 
     def _parse_and_validate_yaml(self) -> dict[str, Any]:
         raw_data = open_yaml(self.mapping_path)


### PR DESCRIPTION
The fixed-mapping AIE codegen path only supported a single fused group, so a SwiGLU could only be emitted as one fully-fused design. This adds mapping-driven multi-group support: authoring two fused_groups in the mapping splits the workload at the group boundary and emits one aie.device design per group (e.g. a gate/up/SiLU/mul front end producing the hidden state, and a down-projection back end consuming it) for an IRON-side full-ELF fusion.

- make_swiglu_mapping(split_groups=True): emit two fused_groups (front + down) instead of one fully-fused group.
- FixedMappingGenerationStage: when a fixed mapping declares more fused groups than the workload cut heuristic finds, derive the cut points from the mapping's group->layer assignment (the mapping is authoritative). Filter runtime_args to each sub-workload's boundary tensors, including the new inter-group fusion edge.
- optimize_allocation_co_with_mapping: when enable_codegen and the mapping has
  >1 fused group, run the allocation + codegen inner pipeline once per group
  (FixedMappingGenerationStage + FusionGroupIterationStage), writing each group's MLIR under <output>/group_i/. Single-group codegen is unchanged.

Verified: two-group SwiGLU 256/512/2048 emits valid group_0 (x,w1,w2->h) and group_1 (h,w3->y) designs; resnet18 fixed-mapping e2e still passes.