### PR TITLE
Feature: Single-hop offchip transfers

### DIFF
--- a/stream/compiler/kernels/__init__.py
+++ b/stream/compiler/kernels/__init__.py
@@ -7,7 +7,9 @@ from stream.compiler.kernels.silu import SiluKernel
 
 AIEKernels = {
     "matvec": lambda utilization: MatVecKernel(utilization, bf16),
-    "silu": lambda utilization, layout: SiluKernel(utilization, bf16),
-    "eltwise_mul": lambda utilization, layout: EltwiseMulKernel(utilization, bf16),
+    # m and n are the kernel tile; they default to the shape the elementwise
+    # kernels were previously fixed to, so existing mappings keep their layout.
+    "silu": lambda utilization, layout, m=32, n=64: SiluKernel(utilization, bf16, m, n, layout),
+    "eltwise_mul": lambda utilization, layout, m=32, n=64: EltwiseMulKernel(utilization, bf16, m, n, layout),
     "gemm": lambda utilization, m, k, n, layout: GemmKernel(utilization, bf16, m, k, n, layout),
 }

--- a/stream/compiler/kernels/aie_kernel.py
+++ b/stream/compiler/kernels/aie_kernel.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from snaxc.dialects.snax import LayoutCast
-from snaxc.ir.tsl import TiledStridedLayout
+from snaxc.ir.tsl import Stride, TiledStride, TiledStridedLayout
 from xdsl.dialects.builtin import FunctionType, StringAttr
 from xdsl.dialects.func import CallOp, FuncOp
 from xdsl.dialects.scf import IndexSwitchOp, YieldOp
@@ -14,6 +14,34 @@ from xdsl.traits import SymbolTable
 from xdsl_aie.dialects.aie import CoreOp, DeviceOp, ObjectFIFOSubviewAccessOp
 
 from stream.compiler.dialects.stream import ComputationNodeOp
+
+# Intrinsic MAC tile of the AIE2p kernels, and the layouts an operand can take.
+R, T = 4, 8
+MAC_TILED = "default"
+CONTIGUOUS = "contiguous"
+VECTOR_LANES = 16
+"""Elements a vectorized elementwise kernel loads per step."""
+
+
+def elementwise_operand_layout(m: int, n: int, layout: str) -> TiledStridedLayout:
+    """Layout of one operand of an elementwise kernel.
+
+    An elementwise kernel walks its operands linearly, so it imposes no layout of
+    its own; the layout only has to match what the operands already are.
+    ``default`` is the r x t tiling a GEMM writes its output in, so an elementwise
+    layer fused behind one needs no transformation. ``contiguous`` is plain row
+    major, which is what a layer reading from and writing to memory wants: its
+    transfers then run the length of a row instead of one MAC tile at a time.
+    """
+    if layout == CONTIGUOUS:
+        return TiledStridedLayout([TiledStride([Stride(n, m)]), TiledStride([Stride(1, n)])])
+    mt, nt = m // R, n // T
+    return TiledStridedLayout(
+        [
+            TiledStride([Stride(R * T * nt, mt), Stride(T, R)]),
+            TiledStride([Stride(R * T, nt), Stride(1, T)]),
+        ]
+    )
 
 
 @dataclass

--- a/stream/compiler/kernels/eltwise_mul.py
+++ b/stream/compiler/kernels/eltwise_mul.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from math import prod
 from typing import cast
 
-from snaxc.ir.tsl import Stride, TiledStride, TiledStridedLayout
+from snaxc.ir.tsl import TiledStridedLayout
 from xdsl.dialects.arith import ConstantOp
 from xdsl.dialects.builtin import (
     AnyDenseElement,
@@ -15,12 +15,19 @@ from xdsl.dialects.func import CallOp
 from xdsl.irdl import Operation
 
 from stream.compiler.dialects.stream import ComputationNodeOp
-from stream.compiler.kernels.aie_kernel import AIEKernel
+from stream.compiler.kernels.aie_kernel import (
+    VECTOR_LANES,
+    AIEKernel,
+    elementwise_operand_layout,
+)
 
 
 @dataclass
 class EltwiseMulKernel(AIEKernel):
     element_type: AnyDenseElement
+    m: int
+    n: int
+    layout: str
 
     @property
     def linkwith_name(self) -> str:
@@ -28,25 +35,17 @@ class EltwiseMulKernel(AIEKernel):
 
     @property
     def function_name(self) -> str:
-        return f"eltwise_mul_{self.element_type}_scalar"
+        """The vectorized variant where the tile fills whole vectors, else the scalar one.
+
+        The multiply is position independent and all three operands share a layout, so
+        the only thing vectorizing asks of the tile is that it leaves no remainder: the
+        vectorized kernel steps a whole vector at a time and has no epilogue.
+        """
+        variant = "vector" if self.m * self.n % VECTOR_LANES == 0 else "scalar"
+        return f"eltwise_mul_{self.element_type}_{variant}"
 
     def operand_layouts(self) -> Sequence[TiledStridedLayout]:
-        # Intrinsic dimensions:
-        r = 4  # ~m
-        s = 8  # ~k  # noqa: F841
-        t = 8  # ~n
-        # Tiled kernel dimensions:
-        mt = 32 // r
-        nt = 64 // t
-        return [
-            TiledStridedLayout(
-                [
-                    TiledStride([Stride(r * t * nt, mt), Stride(t, r)]),
-                    TiledStride([Stride(r * t, nt), Stride(1, t)]),
-                ]
-            )
-            for _ in range(3)
-        ]
+        return [elementwise_operand_layout(self.m, self.n, self.layout) for _ in range(3)]
 
     def function_type(self, op: ComputationNodeOp) -> FunctionType:
         assert op.output is not None

--- a/stream/compiler/kernels/silu.py
+++ b/stream/compiler/kernels/silu.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from math import prod
 from typing import cast
 
-from snaxc.ir.tsl import Stride, TiledStride, TiledStridedLayout
+from snaxc.ir.tsl import TiledStridedLayout
 from xdsl.dialects.arith import ConstantOp
 from xdsl.dialects.builtin import (
     AnyDenseElement,
@@ -15,12 +15,15 @@ from xdsl.dialects.func import CallOp
 from xdsl.irdl import Operation
 
 from stream.compiler.dialects.stream import ComputationNodeOp
-from stream.compiler.kernels.aie_kernel import AIEKernel
+from stream.compiler.kernels.aie_kernel import AIEKernel, elementwise_operand_layout
 
 
 @dataclass
 class SiluKernel(AIEKernel):
     element_type: AnyDenseElement
+    m: int
+    n: int
+    layout: str
 
     @property
     def linkwith_name(self) -> str:
@@ -38,22 +41,7 @@ class SiluKernel(AIEKernel):
         )
 
     def operand_layouts(self) -> Sequence[TiledStridedLayout]:
-        # Intrinsic dimensions:
-        r = 4  # ~m
-        s = 8  # ~k  # noqa: F841
-        t = 8  # ~n
-        # Tiled kernel dimensions:
-        mt = 32 // r
-        nt = 64 // t
-        return [
-            TiledStridedLayout(
-                [
-                    TiledStride([Stride(r * t * nt, mt), Stride(t, r)]),
-                    TiledStride([Stride(r * t, nt), Stride(1, t)]),
-                ]
-            )
-            for _ in range(2)
-        ]
+        return [elementwise_operand_layout(self.m, self.n, self.layout) for _ in range(2)]
 
     def function_call(self, op: ComputationNodeOp) -> Sequence[Operation]:
         len = prod(cast(MemRefType[AnyDenseElement], op.inputs[0].type).get_shape())

--- a/stream/compiler/transforms/aie_convert_ofs.py
+++ b/stream/compiler/transforms/aie_convert_ofs.py
@@ -183,9 +183,17 @@ class StrideSet:
             return new
 
 
+NB_COLUMNS = 8
+
+
+def column_of(tile: str) -> int:
+    """The column of a tile named ``tile_<column>_<row>``."""
+    return int(tile.split("_")[1])
+
+
 @dataclass
 class ChannelToObjectFifoPass(RewritePattern):
-    shim_tiles: dict[str, SSAValue]
+    shim_tiles: dict[int, SSAValue]
     of_count: int = 0
     """
     Converts channels to object fifo definitions
@@ -514,15 +522,16 @@ class ChannelToObjectFifoPass(RewritePattern):
             ofs.extend(spat_ofs)
         return ofs
 
-    def get_tile(self, op: PushOp | PullOp, memtile: str = "") -> SSAValue:
+    def get_tile(self, op: PushOp | PullOp, destination: str = "") -> SSAValue:
         parent = op.parent_op()
         while not isinstance(parent, CoreOp | RuntimeSequenceOp):
             assert parent is not None
             parent = parent.parent_op()
         if isinstance(parent, CoreOp):
             return parent.tile
-        else:  # runtime sequence
-            return self.shim_tiles[memtile]
+        # In the runtime sequence the tile is a shim, one per column, so it is the
+        # destination's column that picks it and not the row it happens to sit on.
+        return self.shim_tiles[column_of(destination)]
 
     def shim_to_mem(
         self,
@@ -556,7 +565,7 @@ class ChannelToObjectFifoPass(RewritePattern):
                     name_base + f"mem_{i}",
                     (2, 2),
                     target_type.get_element_type(),
-                    target_type.get_local_shape() + target_type.get_kernel_shape(),
+                    self.held_shape(target_type),
                 )
                 distributes.append(object_fifo)
 
@@ -579,7 +588,7 @@ class ChannelToObjectFifoPass(RewritePattern):
                 name=name_base + "mem",
                 elemNumber=(2, 2),
                 referenced_type=strensor.get_element_type(),
-                shape=strensor.get_local_shape() + strensor.get_kernel_shape(),
+                shape=self.held_shape(strensor),
             )
             producer.attributes["of"] = object_fifo.sym_name
             for consumer in consumers:
@@ -622,7 +631,7 @@ class ChannelToObjectFifoPass(RewritePattern):
                     name_base + f"mem_{j}",
                     (2, 2),
                     source_type.get_element_type(),
-                    source_type.get_local_shape() + source_type.get_kernel_shape(),
+                    self.held_shape(source_type),
                 )
                 switch_join.append(object_fifo)
 
@@ -653,7 +662,7 @@ class ChannelToObjectFifoPass(RewritePattern):
                 name=name_base + "mem",
                 elemNumber=(2, 2),
                 referenced_type=strensor.get_element_type(),
-                shape=strensor.get_local_shape() + strensor.get_kernel_shape(),
+                shape=self.held_shape(strensor),
             )
             producer.attributes["of"] = object_fifo.sym_name
             for consumer in consumers:
@@ -661,6 +670,17 @@ class ChannelToObjectFifoPass(RewritePattern):
             ofs.append(object_fifo)
 
         return ofs
+
+    @classmethod
+    def held_shape(cls, strensor: StrensorType) -> tuple[int, ...]:
+        """The shape the tile this strensor lives on holds of it.
+
+        A memory tile stages a whole block and redistributes it kernel tile by kernel
+        tile, so it holds the block; a core holds a single kernel tile.
+        """
+        if cls.is_mem(strensor.core_allocation.data[0].data):
+            return strensor.get_local_shape() + strensor.get_kernel_shape()
+        return strensor.get_kernel_shape()
 
     @staticmethod
     def is_shim(tile: str):
@@ -811,6 +831,28 @@ class RealizeLinks(RewritePattern):
         rewriter.erase_op(pull)
 
 
+def transfer_endpoints(op: PushOp | PullOp) -> tuple[StrensorType, StrensorType]:
+    """The strensor where this transfer first lands and where it finally lands.
+
+    A transfer reaches its compute tile either directly or by way of a memory tile,
+    so follow the chain of pushes and pulls to its end instead of assuming how many
+    hops it takes. Both ends coincide when the transfer is direct, which leaves the
+    descriptor below describing the whole movement in one step.
+    """
+    if isinstance(op, PushOp):
+        stops = [next(u.operation for u in op.channel.uses if isinstance(u.operation, PullOp))]
+        while onward := next((u.operation for u in stops[-1].output.uses if isinstance(u.operation, PushOp)), None):
+            stops.append(next(u.operation for u in onward.channel.uses if isinstance(u.operation, PullOp)))
+        first, last = stops[0].output.type, stops[-1].output.type
+    else:
+        stops = [next(u.operation for u in op.channel.uses if isinstance(u.operation, PushOp))]
+        while isinstance(back := stops[-1].input.owner, PullOp):
+            stops.append(next(u.operation for u in back.channel.uses if isinstance(u.operation, PushOp)))
+        first, last = stops[0].input.type, stops[-1].input.type
+    assert isinstance(first, StrensorType) and isinstance(last, StrensorType)
+    return first, last
+
+
 @dataclass
 class TransferToRuntimeSequence(RewritePattern):
     @op_type_rewrite_pattern
@@ -818,25 +860,7 @@ class TransferToRuntimeSequence(RewritePattern):
         if not isinstance(runtime_sequence := op.parent_op(), RuntimeSequenceOp):
             return
 
-        # find strensor type in memtile and compute tile:
-        if isinstance(op, PushOp):
-            mem_op = next(op.operation for op in op.channel.uses if isinstance(op.operation, PullOp))
-            mem_strensor = mem_op.output.type
-            assert isinstance(mem_strensor, StrensorType)
-            mem_push = next(op.operation for op in mem_op.output.uses)
-            assert isinstance(mem_push, PushOp)
-            compute_op = next(op.operation for op in mem_push.channel.uses if isinstance(op.operation, PullOp))
-            compute_strensor = compute_op.output.type
-            assert isinstance(compute_strensor, StrensorType)
-        else:
-            mem_op = next(op.operation for op in op.channel.uses if isinstance(op.operation, PushOp))
-            mem_strensor = mem_op.input.type
-            assert isinstance(mem_strensor, StrensorType)
-            mem_pull = mem_op.input.owner
-            assert isinstance(mem_pull, PullOp)
-            compute_op = next(op.operation for op in mem_pull.channel.uses if isinstance(op.operation, PushOp))
-            compute_strensor = compute_op.input.type
-            assert isinstance(compute_strensor, StrensorType)
+        mem_strensor, compute_strensor = transfer_endpoints(op)
 
         # iterate the zipped mem and compute strensors in reverse (innermost -> outermost)
         def iter_strensors() -> Iterable[tuple[StrensorVar, StrensorVar]]:
@@ -1300,16 +1324,7 @@ class AIEConvertOfs(ModulePass):
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         # create new shim tile
         device = next(op for op in op.walk() if isinstance(op, DeviceOp))
-        shim_tiles = {
-            "tile_0_1": TileOp(0, 0),
-            "tile_1_1": TileOp(1, 0),
-            "tile_2_1": TileOp(2, 0),
-            "tile_3_1": TileOp(3, 0),
-            "tile_4_1": TileOp(4, 0),
-            "tile_5_1": TileOp(5, 0),
-            "tile_6_1": TileOp(6, 0),
-            "tile_7_1": TileOp(7, 0),
-        }
+        shim_tiles = {column: TileOp(column, 0) for column in range(NB_COLUMNS)}
         PatternRewriteWalker(ChannelToObjectFifoPass({x: y.result for x, y in shim_tiles.items()})).rewrite_module(op)
         Rewriter().insert_op(
             [x for x in shim_tiles.values() if x.result.uses], InsertPoint.at_start(device.region.block)

--- a/stream/compiler/transforms/aie_convert_ofs.py
+++ b/stream/compiler/transforms/aie_convert_ofs.py
@@ -100,12 +100,6 @@ class StrideSet:
             result[i * spatial_stride.stride] = type(self)(new_strides)
         return result
 
-    def force_squash(self) -> Self:
-        # Remove all transormations, reduce to 1D transfer
-        total_size = prod(var.size for var in self.strides if var.stride)
-        repeat_size = prod(var.size for var in self.strides if not var.stride)
-        return type(self)((Stride(total_size, 1, 0), Stride(repeat_size, 0, 0)))
-
     def canonicalize(self) -> Self:
         if any(s.spatial for s in self.strides):
             raise RuntimeError("cannot canonicalize strideset with spatial strides")
@@ -947,12 +941,7 @@ class TransferToRuntimeSequence(RewritePattern):
                 if cvar.dim in dim_strides:
                     dim_strides[cvar.dim] *= cvar.size
 
-        stride_dict = StrideSet(tuple(strides)).split()
-        # squash weight transformations:
-        if op.attributes["of"].data in ("of_1_mem", "of_2_mem", "of_3_mem") and False:
-            stride_dict = {x: y.force_squash().legalize() for x, y in stride_dict.items()}
-        else:
-            stride_dict = {x: y.canonicalize().legalize() for x, y in stride_dict.items()}
+        stride_dict = {x: y.canonicalize().legalize() for x, y in StrideSet(tuple(strides)).split().items()}
 
         for i, (spatial_offset, stride_set) in enumerate(stride_dict.items()):
             ofs = op.attributes.get("of")

--- a/stream/cost_model/steady_state_scheduler.py
+++ b/stream/cost_model/steady_state_scheduler.py
@@ -47,6 +47,7 @@ from stream.workload.utils import (
     get_compute_predecessors_successors,
     get_equivalent_dimension,
     get_node_with_largest_resource_allocation,
+    is_reused_on_chip,
 )
 from stream.workload.workload import Workload
 
@@ -338,12 +339,12 @@ class SteadyStateScheduler:
         - a second one from the on-chip memory buffer to the destination.
         This is to ensure that the constant tensor is properly allocated in memory and can be reused across iterations.
 
-        If the accelerator has no on-chip memory tiles (e.g. TPU-like hardware), falls back to a single
-        direct transfer from the source to the destinations (MEM_TO_COMPUTE).
+        Falls back to a single direct transfer from the source to the destinations (MEM_TO_COMPUTE)
+        when the accelerator has no on-chip memory tiles (e.g. TPU-like hardware), or when the tensor
+        is read only once and the memory tile would buy nothing.
         """
         assert isinstance(src, InEdge), f"Expected source of constant transfer to be an InEdge, found {type(src)}"
-        # Fall back to a single direct transfer when no memory tiles are available
-        if not self._get_accelerator_memory_cores():
+        if not self._get_accelerator_memory_cores() or not is_reused_on_chip(self.workload, tensor, dsts):
             transfer_type = self.determine_transfer_type(src, dsts)
             out_name = f"{tensor.name}_1"
             transfer_node, updated_tensors = self.generate_transfer_node(dsts, tensor, transfer_type, out_name)

--- a/stream/workload/utils.py
+++ b/stream/workload/utils.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import sympy as sp
@@ -6,7 +7,7 @@ from xdsl.ir.affine import AffineConstantExpr, AffineDimExpr, AffineExpr
 
 from stream.datatypes import InterCoreTiling, LayerDim
 from stream.workload.iterator_type import check_spatial_unroll_legal, sequential_dims
-from stream.workload.node import ComputationNode, Node, TransferNode
+from stream.workload.node import ComputationNode, HasInputs, HasIterationSpace, Node, Tensor, TransferNode
 from stream.workload.steady_state.iteration_space import (
     IterationVariable,
     IterationVariableType,
@@ -346,3 +347,24 @@ def affine_bounds(expr: AffineExpr, dim_sizes: list[int]) -> tuple[int, int]:
             maxs += a * lo
 
     return mins, maxs
+
+
+def is_reused_on_chip(workload: "Workload", tensor: Tensor, dsts: Sequence[HasInputs]) -> bool:
+    """Whether a destination reads ``tensor`` more than once.
+
+    A destination that iterates a dimension the tensor does not span reads it once per
+    position of that dimension, so holding it in a memory tile saves that many offchip
+    reads. A destination that spans every dimension of the tensor, as an elementwise
+    node does, reads each element once, and a memory tile would only add a second
+    transfer of the same data.
+    """
+    spanned = set(workload.get_tensor_dimensions(tensor))
+    for dst in dsts:
+        if not isinstance(dst, HasIterationSpace):
+            continue
+        # The caller may hold a rebuilt copy of the node; the iteration space is
+        # keyed by the node this workload knows.
+        known = workload.get_node_by_name(dst.name)
+        if set(workload.get_dims(known)) - spanned:
+            return True
+    return False

--- a/tests/unit/test_eltwise_mul_kernel.py
+++ b/tests/unit/test_eltwise_mul_kernel.py
@@ -1,0 +1,32 @@
+"""The elementwise multiply vectorizes when its tile leaves no remainder.
+
+The vectorized kernel steps a whole vector per iteration and has no epilogue, so a
+tile that is not a multiple of the vector width would silently leave its tail
+unwritten. Layout does not enter into it: the multiply is position independent and
+all three operands share a layout.
+"""
+
+from __future__ import annotations
+
+import pytest
+from xdsl.dialects.builtin import bf16
+
+from stream.compiler.kernels.aie_kernel import CONTIGUOUS, MAC_TILED, VECTOR_LANES
+from stream.compiler.kernels.eltwise_mul import EltwiseMulKernel
+
+
+def kernel(m: int, n: int, layout: str = MAC_TILED) -> EltwiseMulKernel:
+    return EltwiseMulKernel(1.0, bf16, m, n, layout)
+
+
+@pytest.mark.parametrize("layout", [MAC_TILED, CONTIGUOUS])
+def test_a_whole_tile_vectorizes(layout: str):
+    assert kernel(32, 64, layout).function_name == "eltwise_mul_bf16_vector"
+
+
+def test_a_tile_with_a_remainder_stays_scalar():
+    assert kernel(1, VECTOR_LANES - 1).function_name == "eltwise_mul_bf16_scalar"
+
+
+def test_both_variants_are_linked_from_the_same_object():
+    assert kernel(32, 64).linkwith_name == kernel(1, 1).linkwith_name == "mul.o"

--- a/tests/unit/test_eltwise_mul_kernel.py
+++ b/tests/unit/test_eltwise_mul_kernel.py
@@ -9,23 +9,25 @@ all three operands share a layout.
 from __future__ import annotations
 
 import pytest
-from xdsl.dialects.builtin import bf16
 
-from stream.compiler.kernels.aie_kernel import CONTIGUOUS, MAC_TILED, VECTOR_LANES
-from stream.compiler.kernels.eltwise_mul import EltwiseMulKernel
+pytest.importorskip("snaxc", reason="the AIE dialects are a separate install, via stream-setup-aie")
 
 
-def kernel(m: int, n: int, layout: str = MAC_TILED) -> EltwiseMulKernel:
+def kernel(m: int, n: int, layout: str = "default"):
+    from xdsl.dialects.builtin import bf16
+
+    from stream.compiler.kernels.eltwise_mul import EltwiseMulKernel
+
     return EltwiseMulKernel(1.0, bf16, m, n, layout)
 
 
-@pytest.mark.parametrize("layout", [MAC_TILED, CONTIGUOUS])
+@pytest.mark.parametrize("layout", ["default", "contiguous"])
 def test_a_whole_tile_vectorizes(layout: str):
     assert kernel(32, 64, layout).function_name == "eltwise_mul_bf16_vector"
 
 
 def test_a_tile_with_a_remainder_stays_scalar():
-    assert kernel(1, VECTOR_LANES - 1).function_name == "eltwise_mul_bf16_scalar"
+    assert kernel(1, 15).function_name == "eltwise_mul_bf16_scalar"
 
 
 def test_both_variants_are_linked_from_the_same_object():

--- a/tests/unit/test_offchip_reuse.py
+++ b/tests/unit/test_offchip_reuse.py
@@ -1,0 +1,83 @@
+"""A constant input is staged in a memory tile only when it is read more than once.
+
+Staging costs a second transfer of the same data, so it pays for itself only when a
+destination reads the tensor repeatedly. A convolution or GEMM does: it sweeps output
+positions with the same operands. An elementwise node does not: it reads each element
+once, and the memory tile would double its offchip traffic for nothing.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import onnx
+import pytest
+from onnx import TensorProto, helper
+
+from stream.parser.onnx.model import ONNXModelParser
+from stream.workload.node import ComputationNode, InEdge
+from stream.workload.utils import is_reused_on_chip
+
+_CONV = "stream/inputs/testing/workload/2conv_1_8_32_32_16_32_3.onnx"
+
+
+def _value(name: str, shape: tuple[int, ...]):
+    return helper.make_tensor_value_info(name, TensorProto.FLOAT, list(shape))
+
+
+def _parse(nodes, inputs, outputs):
+    graph = helper.make_graph(nodes, "g", inputs, outputs, [])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+        onnx.save(model, f.name)
+        parser = ONNXModelParser(f.name)
+        parser.run()
+    return parser.workload
+
+
+def _offchip_inputs(workload):
+    """Each tensor arriving from offchip, with the computation nodes that read it."""
+    for node in workload.dataflow_sort():
+        if not isinstance(node, InEdge):
+            continue
+        for tensor in node.outputs:
+            consumers = [c for c in workload.successors(node) if isinstance(c, ComputationNode)]
+            if consumers:
+                yield tensor, consumers
+
+
+@pytest.fixture(scope="module")
+def convolution():
+    parser = ONNXModelParser(_CONV)
+    parser.run()
+    return parser.workload
+
+
+@pytest.fixture(scope="module")
+def elementwise():
+    return _parse(
+        [helper.make_node("Mul", ["A", "B"], ["C"], name="mul")],
+        [_value("A", (256, 2048)), _value("B", (256, 2048))],
+        [_value("C", (256, 2048))],
+    )
+
+
+def test_convolution_operands_are_reused(convolution):
+    """Every operand is swept by an iteration dimension it does not span."""
+    operands = list(_offchip_inputs(convolution))
+    assert operands
+    for tensor, consumers in operands:
+        assert is_reused_on_chip(convolution, tensor, consumers), tensor.name
+
+
+def test_elementwise_operands_are_not_reused(elementwise):
+    """Both operands span the whole iteration space, so each element is read once."""
+    operands = list(_offchip_inputs(elementwise))
+    assert len(operands) == 2
+    for tensor, consumers in operands:
+        assert not is_reused_on_chip(elementwise, tensor, consumers), tensor.name
+
+
+def test_a_tensor_with_no_destination_is_not_reused(convolution):
+    tensor, _ = next(iter(_offchip_inputs(convolution)))
+    assert not is_reused_on_chip(convolution, tensor, [])


### PR DESCRIPTION
Support single-hop transfers directly from offchip to compute even when a dedicated memory core is present. This can be beneficial for no-reuse operators (e.g. elementwise activations or multiplications), as in the AIE SwiGLU design.