### PR TITLE
Convolution Asymmetric Padding

### DIFF
--- a/stream/parser/onnx/conv.py
+++ b/stream/parser/onnx/conv.py
@@ -15,6 +15,7 @@ class ConvParser(OnnxOperatorParser):
     def get_mappings_2d_conv(self) -> tuple[AffineMap, AffineMap, AffineMap]:
         strides = self.get_node_attribute_ints("strides")
         required_strides_length = 2
+        required_pads_length = 4
         if not strides:
             strides = [1, 1]
         assert len(strides) == required_strides_length, "Strides should be 2D for 2D convolution."
@@ -22,12 +23,13 @@ class ConvParser(OnnxOperatorParser):
         pads = self.get_node_attribute_ints("pads")
         if not pads:
             pads = [0, 0, 0, 0]
-        if not all(p == pads[0] for p in pads):
-            raise NotImplementedError("Asymmetric padding is not supported yet.")
-        p = pads[0]
+        assert len(pads) == required_pads_length, "Pads should be 2D for 2D convolution."
+        pad_top, pad_left, _pad_bottom, _pad_right = pads
 
         return (
-            AffineMap.from_callable(lambda b, ox, oy, fx, fy, c, k: (b, c, sy * oy + fy - p, sx * ox + fx - p)),
+            AffineMap.from_callable(
+                lambda b, ox, oy, fx, fy, c, k: (b, c, sy * oy + fy - pad_top, sx * ox + fx - pad_left)
+            ),
             AffineMap.from_callable(lambda b, ox, oy, fx, fy, c, k: (k, c, fy, fx)),
             AffineMap.from_callable(lambda b, ox, oy, fx, fy, c, k: (b, k, oy, ox)),
         )

--- a/tests/unit/test_conv_parser.py
+++ b/tests/unit/test_conv_parser.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import tempfile
+
+import onnx
+from onnx import TensorProto, helper
+from xdsl.ir.affine import AffineBinaryOpExpr
+
+from stream.parser.onnx.model import ONNXModelParser
+
+
+def _vi(name: str, shape: tuple[int, ...]):
+    return helper.make_tensor_value_info(name, TensorProto.FLOAT, list(shape))
+
+
+def test_conv_accepts_asymmetric_2d_padding():
+    weight = helper.make_tensor("W", TensorProto.FLOAT, [4, 8, 3, 3], [])
+    node = helper.make_node(
+        "Conv",
+        ["X", "W"],
+        ["Y"],
+        name="ConvAsymPad",
+        kernel_shape=[3, 3],
+        pads=[1, 2, 0, 3],
+    )
+    graph = helper.make_graph(
+        [node],
+        "g",
+        [_vi("X", (1, 8, 8, 8))],
+        [_vi("Y", (1, 4, 7, 11))],
+        initializer=[weight],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+    with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+        onnx.save(model, f.name)
+        parser = ONNXModelParser(f.name)
+        parser.run()
+
+    conv = parser.workload.get_computation_nodes()[0]
+    input_map = conv.operand_mapping[0]
+    input_y = input_map.results[2]
+    input_x = input_map.results[3]
+
+    assert conv.name == "ConvAsymPad"
+    assert isinstance(input_y, AffineBinaryOpExpr)
+    assert isinstance(input_x, AffineBinaryOpExpr)
+    assert int(input_y.eval([0, 0, 0, 0, 0, 0, 0], [])) == -1
+    assert int(input_x.eval([0, 0, 0, 0, 0, 0, 0], [])) == -2


### PR DESCRIPTION
This PR adds support for asymmetric padding in the ONNX Conv parser.

**Changes**

* Remove the previous rejection of asymmetric Conv padding.
* Parse ONNX padding as `[top, left, bottom, right]`.
* Apply the top/left padding offsets correctly in the affine input mapping:

  * `sy * oy + fy - pad_top`
  * `sx * ox + fx - pad_left`
* Add a regression test using `pads=[1, 2, 0, 3]`.

**Verification**

* `test_conv_parser.py`: 1 passed
* `test_concat_parser.py`: 3 passed
