### PR TITLE
Fix two AIE designs that hang on hardware

### DIFF
--- a/stream/compiler/transforms/aie_convert_ofs.py
+++ b/stream/compiler/transforms/aie_convert_ofs.py
@@ -84,18 +84,16 @@ class StrideSet:
     def total_size(self) -> int:
         return self.repeats() * self.size()
 
-    def split(self) -> dict[int, Self]:
+    def split(self, into: int = 1) -> list[tuple[int, Self]]:
+        """One (offset, strides) pair per destination fifo, replicas included."""
         spatial_strides = [s for s in self.strides if s.spatial]
         if len(spatial_strides) == 0:
-            return {0: self}
+            return [(0, self)] * into
         assert len(spatial_strides) == 1
         spatial_stride = spatial_strides[0]
         idx = self.strides.index(spatial_stride)
         new_strides = self.strides[:idx] + self.strides[idx + 1 :]
-        result = {}
-        for i in range(spatial_stride.size):
-            result[i * spatial_stride.stride] = type(self)(new_strides)
-        return result
+        return [(i * spatial_stride.stride, type(self)(new_strides)) for i in range(spatial_stride.size)]
 
     def canonicalize(self) -> Self:
         if any(s.spatial for s in self.strides):
@@ -938,15 +936,12 @@ class TransferToRuntimeSequence(RewritePattern):
                 if cvar.dim in dim_strides:
                     dim_strides[cvar.dim] *= cvar.size
 
-        stride_dict = {x: y.canonicalize().legalize() for x, y in StrideSet(tuple(strides)).split().items()}
+        ofs = op.attributes.get("of")
+        assert isa(ofs, StringAttr) or isa(ofs, ArrayAttr[StringAttr])
+        names = [ofs] if isinstance(ofs, StringAttr) else list(ofs.data)
+        groups = [(x, y.canonicalize().legalize()) for x, y in StrideSet(tuple(strides)).split(len(names))]
 
-        for i, (spatial_offset, stride_set) in enumerate(stride_dict.items()):
-            ofs = op.attributes.get("of")
-            assert isa(ofs, StringAttr) or isa(ofs, ArrayAttr[StringAttr])
-            if isinstance(ofs, StringAttr):
-                of = ofs
-            else:
-                of = ofs.data[i]
+        for of, (spatial_offset, stride_set) in zip(names, groups, strict=True):
             hardware_strides = stride_set.strides[:4]
             # Perform software for loop unrolling:
             software_strides = stride_set.strides[4:]
@@ -1343,3 +1338,19 @@ class AIEConvertOfs(ModulePass):
         PatternRewriteWalker(TransferToObjectFIFOPattern()).rewrite_module(op)
         PatternRewriteWalker(RemoveChannels()).rewrite_module(op)
         PatternRewriteWalker(RemoveEmptyCores()).rewrite_module(op)
+        _verify_shim_fifos_are_fed(op)
+
+
+def _verify_shim_fifos_are_fed(module: ModuleOp) -> None:
+    """Fail the build on a shim fifo nothing fills, which would hang on hardware."""
+    shim_rows = {tile.result: tile.row.value.data for tile in module.walk() if isinstance(tile, TileOp)}
+    fed = {task.alloc.string_value() for task in module.walk() if isinstance(task, DmaConfigureTaskForOp)}
+    starved = [
+        fifo.sym_name.data
+        for fifo in module.walk()
+        if isinstance(fifo, ObjectFifoOp) and shim_rows.get(fifo.producerTile) == 0 and fifo.sym_name.data not in fed
+    ]
+    if starved:
+        raise RuntimeError(
+            f"objectfifo(s) produced by a shim tile with no runtime transfer to fill them: {', '.join(sorted(starved))}"
+        )

--- a/stream/opt/allocation/constraint_optimization/context.py
+++ b/stream/opt/allocation/constraint_optimization/context.py
@@ -132,6 +132,18 @@ class NamespaceConstraints:
     ) -> None:
         """Enforce FIFO-depth limits for cores in this namespace."""
 
+    # ---- memory-tile reuse ----
+
+    def add_memory_reuse_constraints(
+        self,
+        model: SolverModel,
+        transfers: list[tuple[Core, LinExpr, LinExpr]],
+    ) -> None:
+        """Narrow how much longer a memory tile may hold a tensor than its reader.
+
+        Each entry is (memory tile, its reuse level, the compute tile's).
+        """
+
     # ---- buffer descriptors ----
 
     def add_buffer_descriptor_constraints(
@@ -203,6 +215,23 @@ class AIE2Constraints(NamespaceConstraints):
             model.add_constr(
                 expr <= core.max_object_fifo_depth,
                 name=f"aie2_obj_fifo_depth_Core_{core.id}",
+            )
+
+    # ---- memory-tile reuse ----
+
+    def add_memory_reuse_constraints(
+        self,
+        model: SolverModel,
+        transfers: list[tuple[Core, LinExpr, LinExpr]],
+    ) -> None:
+        """An AIE memory tile cannot re-send an object it holds, so it may not outlive
+        its reader. Liftable once the object FIFO repeat count is emitted."""
+        for core, mem_level, compute_level in transfers:
+            if not self.applies_to(core):
+                continue
+            model.add_constr(
+                mem_level == compute_level,
+                name=f"aie2_mem_reuse_eq_Core_{core.id}",
             )
 
     # ---- buffer descriptors ----
@@ -277,6 +306,15 @@ class TransferAndTensorContext:
         """Dispatch object-FIFO depth constraints to all namespace strategies."""
         for ns in self.namespace_constraints:
             ns.add_object_fifo_constraints(model, object_fifo_depth)
+
+    def add_memory_reuse_constraints(
+        self,
+        model: SolverModel,
+        transfers: list[tuple[Core, LinExpr, LinExpr]],
+    ) -> None:
+        """Dispatch memory-tile reuse constraints to all namespace strategies."""
+        for ns in self.namespace_constraints:
+            ns.add_memory_reuse_constraints(model, transfers)
 
     def add_buffer_descriptor_constraints(
         self,

--- a/stream/opt/allocation/constraint_optimization/transfer_and_tensor_allocation.py
+++ b/stream/opt/allocation/constraint_optimization/transfer_and_tensor_allocation.py
@@ -43,6 +43,7 @@ from stream.opt.allocation.constraint_optimization.timeslot_allocation import (
 from stream.opt.allocation.constraint_optimization.utils import get_active_latency
 from stream.opt.solver import (
     ConstraintSelection,
+    LinExpr,
     ObjectiveLevel,
     PipeliningModel,
     SolverBackend,
@@ -940,6 +941,8 @@ class TransferAndTensorAllocator:
         memory tile and brought back, so the compute tile owns it until it is complete
         and the memory tile inherits exactly that residency.
         """
+        memory_reuse: list[tuple[Core, LinExpr, LinExpr]] = []
+        namespace_cores = list({c.namespace: c for c in self.mem_cores}.values())
         for tr in self.transfer_nodes:
             inputs = tr.inputs
             outputs = tr.outputs
@@ -963,6 +966,18 @@ class TransferAndTensorAllocator:
                         self._reuse_level_expr(input_tensor) >= self._reuse_level_expr(output_tensor),
                         name=f"reuse_ge_output_{tr.name}",
                     )
+                    # Whether that extra residency is realisable is a target property.
+                    # One core per namespace is enough; the rest repeat the constraint.
+                    memory_reuse.extend(
+                        (
+                            core,
+                            self._reuse_level_expr(input_tensor),
+                            self._reuse_level_expr(output_tensor),
+                        )
+                        for core in namespace_cores
+                    )
+
+        self.context.add_memory_reuse_constraints(self.model, memory_reuse)
 
     def _force_reuse_includes_spatial(self):
         """


### PR DESCRIPTION
Two designs that build fine but hang on hardware, both from how a memory tile holds and forwards data. Each one costs a 60 second timeout with nothing to show for it, so this also adds a check that turns the first class into a build error.

- Emit one runtime transfer per destination fifo. When memory tiles hold replicas rather than slices there is no spatial stride to split on, so only the first fifo got a transfer and the cores behind the rest blocked on their first acquire.
- Fail the build when an objectfifo produced by a shim tile has no transfer filling it.
- Stop an AIE memory tile from outliving its reader. Way-in reuse lets it hold a tensor longer than the compute tile reads it, but it cannot re-send an object it holds, so the reader is starved and the design deadlocks. This goes through the existing namespace seam, so other targets keep the general rule.

Both were found by diffing the generated MLIR against a known good design, and both fixes are confirmed on Strix: k=1, k=2 and k=5 all pass again. The reuse narrowing can be lifted once the object FIFO repeat count is derived and emitted, which is noted in the code.
