### PR TITLE
Emit AIE tracing with the v1.4.0 trace dialect

### DIFF
--- a/docs/source/aie_calibration.md
+++ b/docs/source/aie_calibration.md
@@ -1,0 +1,83 @@
+# Measured against predicted, SwiGLU prefill on Strix
+
+First closed loop between the MILP's latency estimate and hardware trace, for
+`swiglu_prefill_stream` k=1 (256/512/2048, npu2, 4x8). The point here is the method and
+where the two disagree, not the absolute numbers, which are one design on one part.
+
+## The two sides
+
+Prediction, from `outputs/<experiment>/tetra/slot_latency_breakdown.yaml`:
+
+| | cycles |
+|---|---|
+| `iter_step` (compute per iteration) | 574 |
+| `overlap` | 1040 |
+| `latency_per_iteration` | 1614 |
+| `total_latency` | 2352144 |
+
+Measurement, from the core trace decoded to Perfetto JSON (64 KiB buffer, one traced
+core, 1.25 GHz):
+
+| | |
+|---|---|
+| kernel invocations paired | 276 |
+| kernel duration, median | **575 cycles** |
+| kernel duration, min / max | 198 / 575 |
+| `LOCK_STALL` total | 626325 cycles |
+| `INSTR_VECTOR` total | 50012 cycles |
+| trace window | 800138 cycles (640 us) |
+
+Dispatch wall clock, untraced, best of three: **1173.5 us** = 1466875 cycles.
+
+## Where the model is right
+
+**The compute estimate is essentially exact.** Predicted `iter_step` 574 cycles against a
+measured median kernel duration of 575. That is 0.2% on the quantity the cost model is
+most directly responsible for, and it says the per-core roofline and the kernel's own
+cost are being modelled correctly.
+
+## Where it is wrong
+
+**Stalling dominates and is under-modelled.** `LOCK_STALL` accounts for 626325 of the
+800138 cycles in the traced window, 78%. Spread over the 276 invocations that is ~2269
+cycles of stall per invocation against a predicted `overlap` of 1040, so the waiting is
+roughly 2.2x what the model expects.
+
+**End to end the model is conservative by 1.60x**: 2352144 predicted against 1466875
+measured. Note this runs the *opposite* way to the per-invocation stall gap, so the two
+are not the same error seen twice. Reconciling them needs the iteration count the model
+assumes to be checked against the trace, which the 64 KiB window is too short to do.
+
+## Reading these numbers honestly
+
+The trace covers **55%** of the dispatch. A 64 KiB buffer fills before the run ends, so
+every total above is a lower bound and only the per-invocation statistics are safe to
+quote. A larger buffer would fix this: 1 MiB currently fails to build and that is worth
+chasing before any calibration work leans on totals.
+
+Only **one core** is traced. Whole-array k=5 cannot be traced at all -- the design
+saturates the stream switches and trace packet flows have nowhere to route, failing with
+`Unable to find a legal routing` even at one tile per group. So this is one core's view
+of a 32-core design, and the stall figure in particular may not be representative of
+cores on different columns.
+
+`INSTR_EVENT_0`/`INSTR_EVENT_1` pairing assumes the two events bracket one kernel call.
+276 pairs from 277 starts and 276 ends is consistent with that, but the pairing is by
+arrival order, so a dropped packet would silently shift every subsequent span.
+
+## What to do with this
+
+The split matters more than either number: compute is modelled well, waiting is not. That
+points calibration effort at the transfer and dependency model rather than the core cost
+model, and it is the kind of conclusion a wall-clock comparison alone could never reach --
+a single 1.60x number would have suggested scaling the whole estimate, which would have
+made the compute term wrong to fix the stall term.
+
+## Reproducing
+
+```
+IRON_TRACE_SIZE=65536 IRON_TRACE_NTILES=1 pytest iron/operators/swiglu_prefill_stream -k "k_1 and iter0"
+```
+then decode with `aie.utils.trace.parse`, passing MLIR that has been through
+`--aie-trace-to-config --aie-trace-pack-reg-writes --aie-inline-trace-config` (the parser
+reads `aiex.npu.write32`, not the `aie.trace` dialect).

--- a/scripts/main_swiglu.py
+++ b/scripts/main_swiglu.py
@@ -112,7 +112,9 @@ if __name__ == "__main__":
     )
     parser.add_argument("--in_dtype", type=str, default="bf16", help="Input data type (default: bf16)")
     parser.add_argument("--out_dtype", type=str, default="bf16", help="Output data type (default: bf16)")
-    parser.add_argument("--trace_size", type=int, default=1048576, help="Size of the trace buffer (default: 1048576)")
+    parser.add_argument(
+        "--trace_size", type=int, default=0, help="Trace buffer size in bytes, 0 to disable (default: 0)"
+    )
     parser.add_argument("--rows", type=int, default=4, help="Number of AIE rows to use (has to be 4)")
     parser.add_argument("--cols", type=int, default=8, help="Number of AIE columns to use (default: 8)")
     parser.add_argument("--npu", type=str, default="npu2", help="NPU type to target (default: npu2)")

--- a/stream/aie_setup.py
+++ b/stream/aie_setup.py
@@ -27,8 +27,7 @@ from pathlib import Path
 
 # Installed --no-deps: they pin xdsl to a git commit that would otherwise clobber the released
 # xdsl that stream-dse depends on.
-# TODO: repoint at xdslproject/xdsl-aie once PR 28 merges; this fork commit is a stand-in.
-_XDSL_AIE = "git+https://github.com/KULeuven-MICAS/xdsl-aie.git@2674ab272ce4f9597ff8afd77772527f2d887ab4"
+_XDSL_AIE = "git+https://github.com/xdslproject/xdsl-aie.git@0756a2582ec60095bf129288bdcb722462365799"
 _SNAX_MLIR = "git+https://github.com/kuleuven-micas/snax-mlir.git@1c01c5d100df128c9fa01d3336ebea98e19b20cf"
 
 # Opt-in only (--with-mlir-aie). Codegen emits the v1.4.0 buffer descriptor form, which

--- a/stream/aie_setup.py
+++ b/stream/aie_setup.py
@@ -27,7 +27,8 @@ from pathlib import Path
 
 # Installed --no-deps: they pin xdsl to a git commit that would otherwise clobber the released
 # xdsl that stream-dse depends on.
-_XDSL_AIE = "git+https://github.com/xdslproject/xdsl-aie.git@bcc307f47e63e8566db19e19950cdee5368ead6a"
+# TODO: repoint at xdslproject/xdsl-aie once PR 28 merges; this fork commit is a stand-in.
+_XDSL_AIE = "git+https://github.com/KULeuven-MICAS/xdsl-aie.git@2674ab272ce4f9597ff8afd77772527f2d887ab4"
 _SNAX_MLIR = "git+https://github.com/kuleuven-micas/snax-mlir.git@1c01c5d100df128c9fa01d3336ebea98e19b20cf"
 
 # Opt-in only (--with-mlir-aie). Codegen emits the v1.4.0 buffer descriptor form, which

--- a/stream/api.py
+++ b/stream/api.py
@@ -70,7 +70,8 @@ def optimize_allocation_co_with_mapping(  # noqa: PLR0913, PLR0912
     skip_if_exists: bool = False,
     temporal_mapping_type: str = "uneven",
     enable_codegen: bool = False,
-    trace_size: int = 1048576,
+    trace_size: int = 0,
+    trace_max_tiles: int = 31,
     nb_cols_to_use: int = 4,
     npu: str = "npu2",
     backend: str = "ortools_gscip",
@@ -125,6 +126,7 @@ def optimize_allocation_co_with_mapping(  # noqa: PLR0913, PLR0912
             output_path=output_path,
             temporal_mapping_type=temporal_mapping_type,  # required by CoreCostEstimationStage
             trace_size=trace_size,
+            trace_max_tiles=trace_max_tiles,
             nb_cols_to_use=nb_cols_to_use,  # required by ConstraintOptimizationAllocationStage
             backend=_backend_enum.value,
             constraint_selection=constraint_selection,
@@ -391,7 +393,8 @@ def optimize_mapping(  # noqa: PLR0913
     skip_if_exists: bool = False,
     temporal_mapping_type: str = "uneven",
     enable_codegen: bool = False,
-    trace_size: int = 1048576,
+    trace_size: int = 0,
+    trace_max_tiles: int = 31,
     nb_cols_to_use: int = 8,
     nb_rows_to_use: int = 4,
     seq_len_tile_size: int = 32,
@@ -457,6 +460,7 @@ def optimize_mapping(  # noqa: PLR0913
             output_path=output_path,
             temporal_mapping_type=temporal_mapping_type,  # required by CoreCostEstimationStage
             trace_size=trace_size,
+            trace_max_tiles=trace_max_tiles,
             nb_cols_to_use=nb_cols_to_use,  # required by ConstraintOptimizationAllocationStage
             nb_rows_to_use=nb_rows_to_use,  # used by MappingGenerator for shape-aware tiling
             seq_len_tile_size=seq_len_tile_size,

--- a/stream/compiler/transforms/aie_add_tracing_script.py
+++ b/stream/compiler/transforms/aie_add_tracing_script.py
@@ -1,154 +1,106 @@
-try:
-    import aie.utils.trace as trace_utils  # pyright: ignore[reportMissingImports]
-    from aie.dialects.aie import AIEDevice, device, tile  # pyright: ignore[reportMissingImports]
-    from aie.extras.context import mlir_mod_ctx
-
-    _AIE_AVAILABLE = True
-except ImportError:
-    trace_utils = None  # type: ignore[assignment]
-    AIEDevice = None  # type: ignore[assignment]
-    device = None  # type: ignore[assignment]
-    tile = None  # type: ignore[assignment]
-    mlir_mod_ctx = None  # type: ignore[assignment]
-    _AIE_AVAILABLE = False
+from dataclasses import dataclass, field
 
 from xdsl.context import Context
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import Operation
-from xdsl.parser import Parser
+from xdsl.ir import Block, Region
 from xdsl.passes import ModulePass
 from xdsl.rewriter import InsertPoint, Rewriter
-from xdsl_aie.dialects.aie import DeviceOp, TileOp
-from xdsl_aie.dialects.aiex import RuntimeSequenceOp
+from xdsl_aie.dialects.aie import (
+    CoreOp,
+    DeviceOp,
+    EndOp,
+    RuntimeSequenceOp,
+    TraceEventOp,
+    TraceHostConfigOp,
+    TraceModeOp,
+    TraceOp,
+    TracePacketOp,
+    TraceStartConfigOp,
+    TraceStartOp,
+    TraceStopOp,
+)
+
+# The instruction events bracket each kernel call and the stall events explain the gaps.
+# No port events: those need a DMA channel, which is only assigned later.
+DEFAULT_EVENTS = (
+    "INSTR_EVENT_0",
+    "INSTR_EVENT_1",
+    "MEMORY_STALL",
+    "LOCK_STALL",
+    "INSTR_VECTOR",
+)
+
+# A trace unit takes eight event slots and mlir-aie expects all of them.
+_EVENT_SLOTS = 8
+
+# Packet ids run 1..31. Routing usually runs out first, so pick fewer than this.
+MAX_TRACED_TILES = 31
 
 
+def _coords(tile) -> tuple[int, int]:
+    owner = tile.owner
+    return (owner.col.value.data, owner.row.value.data)
+
+
+@dataclass(frozen=True)
 class AIEAddTracingScript(ModulePass):
+    """Emit trace configuration for the tiles that run kernels.
+
+    Lowering turns it into the packet flow, shim allocation and register writes, and
+    appends a trace buffer to the runtime sequence for the host to supply.
+    """
+
     name = "aie-add-tracing-script"
 
-    def __init__(self, trace_size=1048576):
-        if not _AIE_AVAILABLE:
-            raise ImportError(
-                "AIEAddTracingScript requires the optional AIE toolchain. "
-                "Install it by running `stream-setup-aie` after installing stream-dse "
-                "(Python 3.12 or 3.13 required)."
-            )
-        self.trace_size = trace_size
+    trace_size: int = 1048576
+    max_tiles: int = MAX_TRACED_TILES
+    events: tuple[str, ...] = field(default_factory=lambda: DEFAULT_EVENTS)
+    # (col, row) to trace. Empty means every tile with a kernel, up to max_tiles.
+    tiles: tuple[tuple[int, int], ...] = ()
 
     def apply(self, ctx: Context, op: ModuleOp) -> None:
+        device = next((o for o in op.walk() if isinstance(o, DeviceOp)), None)
+        sequence = next((o for o in op.walk() if isinstance(o, RuntimeSequenceOp)), None)
+        if device is None or sequence is None:
+            return
+
+        # Tracing a tile only says something if a kernel runs on it.
+        tiles = list(dict.fromkeys(core.tile for core in op.walk() if isinstance(core, CoreOp)))
+        if self.tiles:
+            wanted = set(self.tiles)
+            tiles = [t for t in tiles if _coords(t) in wanted]
+            missing = wanted - {_coords(t) for t in tiles}
+            if missing:
+                raise ValueError(f"no kernel runs on tile(s) {sorted(missing)}, so they cannot be traced")
+        if len(tiles) > self.max_tiles:
+            tiles = tiles[: self.max_tiles]
+
+        if not tiles:
+            return
+
+        events = tuple(self.events)[:_EVENT_SLOTS]
+        events += ("NONE",) * (_EVENT_SLOTS - len(events))
+
         rewriter = Rewriter()
+        names: list[str] = []
+        for index, tile in enumerate(tiles):
+            name = f"trace_core_{index}"
+            names.append(name)
+            body = Block(
+                [
+                    TraceModeOp(),
+                    TracePacketOp(),
+                    *(TraceEventOp(event) for event in events),
+                    TraceStartOp(),
+                    TraceStopOp(),
+                    EndOp(),
+                ]
+            )
+            # The device block already ends in aie.end.
+            rewriter.insert_op(
+                TraceOp(name, tile, Region(body)),
+                InsertPoint.before(device.region.block.last_op),
+            )
 
-        # 1: Get packet flow
-        # find shim tile and compute tile:
-        shim_tile = None
-        # compute_tile2 = None
-        compute_tiles: dict[tuple[int, int], TileOp] = {}
-        for tile_op in op.walk():
-            if isinstance(tile_op, TileOp):
-                match tile_idx := (tile_op.col.value.data, tile_op.row.value.data):
-                    case (0, 0):
-                        shim_tile = tile_op
-                    case _:
-                        compute_tiles[tile_idx] = tile_op
-        assert shim_tile is not None
-
-        with mlir_mod_ctx() as aie_ctx:
-
-            @device(AIEDevice.npu2)
-            def device_body():
-                shim_tile_aie = tile(0, 0)
-                tiles_to_trace = []
-                for tile_idx in compute_tiles:
-                    tile_aie = tile(*tile_idx)
-                    tiles_to_trace.append(tile_aie)
-                trace_utils.configure_packet_tracing_flow(tiles_to_trace, shim_tile_aie)
-
-        packet_flow_str = aie_ctx.module.body.operations[0].get_asm(print_generic_op_form=True)
-
-        # modify to fit into our own IR:
-        parser = Parser(Context(allow_unregistered=True), packet_flow_str)
-        module = parser.parse_module()
-
-        packet_flow_ops: list[Operation] = [
-            op for op in module.body.block.first_op.regions[0].block.ops if op.op_name.data == "aie.packet_flow"
-        ]
-        for packet_flow_op, compute_tile in zip(packet_flow_ops, compute_tiles.values(), strict=True):
-            packet_flow_op.detach()
-            packet_flow_op.regions[0].block.first_op.operands[0] = compute_tile.result
-            packet_flow_op.regions[0].block.first_op.next_op.operands[0] = shim_tile.result
-        # for op in module.body.block.first_op.regions[0].block.ops:
-        #     if op.op_name.data in ("aie.tile", "aie.end"):
-        #         continue
-        #     op.detach()
-        #     op.regions[0].block.first_op.operands[0] = compute_tile2.result
-        #     op.regions[0].block.first_op.next_op.operands[0] = shim_tile.result
-        #     packet_flow_ops.append(op)
-        # packet_flow_op = module.body.block.first_op.regions[0].block.last_op.prev_op  # pyright: ignore
-        # assert isinstance(packet_flow_op, Operation)
-        # packet_flow_op.detach()
-        # packet_flow_op.regions[0].block.first_op.operands[0] = compute_tile2.result
-        # packet_flow_op.regions[0].block.first_op.next_op.operands[0] = shim_tile.result
-
-        # insert into device body:
-        for device_op in op.walk():
-            if isinstance(device_op, DeviceOp):
-                rewriter.insert_op(packet_flow_ops, InsertPoint.at_end(device_op.region.block))
-
-        # 2: Runtime sequence thingies
-        #
-        with mlir_mod_ctx() as aie_ctx:
-
-            @device(AIEDevice.npu2)
-            def device_body():
-                shim_tile_aie = tile(0, 0)
-                tiles_to_trace = []
-                for tile_idx in compute_tiles:
-                    tile_aie = tile(*tile_idx)
-                    tiles_to_trace.append(tile_aie)
-
-                trace_utils.configure_packet_tracing_aie2(
-                    tiles_to_trace=tiles_to_trace,
-                    shim=shim_tile_aie,
-                    trace_size=self.trace_size,
-                    coretile_events=[
-                        # captures input A (PORT_RUNNING_0, at port number 1, master for inputs)
-                        trace_utils.PortEvent(
-                            trace_utils.CoreEvent.PORT_RUNNING_0,
-                            port_number=1,
-                            master=True,
-                        ),
-                        # captures input B (PORT_RUNNING_1, at port number 2, master for inputs)
-                        trace_utils.PortEvent(
-                            trace_utils.CoreEvent.PORT_RUNNING_1,
-                            port_number=2,
-                            master=True,
-                        ),
-                        # captures output C (PORT_RUNNING_2, at port number 1, slave for outputs)
-                        trace_utils.PortEvent(
-                            trace_utils.CoreEvent.PORT_RUNNING_2,
-                            port_number=1,
-                            master=False,
-                        ),
-                        trace_utils.CoreEvent.INSTR_EVENT_0,
-                        trace_utils.CoreEvent.INSTR_EVENT_1,
-                        trace_utils.CoreEvent.MEMORY_STALL,
-                        trace_utils.CoreEvent.LOCK_STALL,
-                        trace_utils.CoreEvent.INSTR_VECTOR,
-                    ],
-                )
-
-        runtime_str = aie_ctx.module.body.operations[0].get_asm(print_generic_op_form=True)
-
-        parser = Parser(Context(allow_unregistered=True), runtime_str)
-        module = parser.parse_module()
-
-        # Find runtime sequence:
-        for runtime_sequence in op.walk():
-            if isinstance(runtime_sequence, RuntimeSequenceOp):
-                # Insert all ops at start
-                insert_point = InsertPoint.at_start(runtime_sequence.body.block)
-                for operation in module.body.block.first_op.regions[0].block.ops:
-                    if operation.op_name.data in ("aie.tile", "aie.end"):
-                        continue
-                    operation.detach()
-                    rewriter.insert_op(operation, insert_point)
-                    insert_point = InsertPoint.after(operation)
+        configs = [TraceHostConfigOp(self.trace_size), *(TraceStartConfigOp(n) for n in names)]
+        rewriter.insert_op(configs, InsertPoint.at_start(sequence.body.block))

--- a/stream/compiler/transforms/aie_convert_ofs.py
+++ b/stream/compiler/transforms/aie_convert_ofs.py
@@ -84,18 +84,16 @@ class StrideSet:
     def total_size(self) -> int:
         return self.repeats() * self.size()
 
-    def split(self) -> dict[int, Self]:
+    def split(self, into: int = 1) -> list[tuple[int, Self]]:
+        """One (offset, strides) pair per destination fifo, replicas included."""
         spatial_strides = [s for s in self.strides if s.spatial]
         if len(spatial_strides) == 0:
-            return {0: self}
+            return [(0, self)] * into
         assert len(spatial_strides) == 1
         spatial_stride = spatial_strides[0]
         idx = self.strides.index(spatial_stride)
         new_strides = self.strides[:idx] + self.strides[idx + 1 :]
-        result = {}
-        for i in range(spatial_stride.size):
-            result[i * spatial_stride.stride] = type(self)(new_strides)
-        return result
+        return [(i * spatial_stride.stride, type(self)(new_strides)) for i in range(spatial_stride.size)]
 
     def canonicalize(self) -> Self:
         if any(s.spatial for s in self.strides):
@@ -938,15 +936,12 @@ class TransferToRuntimeSequence(RewritePattern):
                 if cvar.dim in dim_strides:
                     dim_strides[cvar.dim] *= cvar.size
 
-        stride_dict = {x: y.canonicalize().legalize() for x, y in StrideSet(tuple(strides)).split().items()}
+        ofs = op.attributes.get("of")
+        assert isa(ofs, StringAttr) or isa(ofs, ArrayAttr[StringAttr])
+        names = [ofs] if isinstance(ofs, StringAttr) else list(ofs.data)
+        groups = [(x, y.canonicalize().legalize()) for x, y in StrideSet(tuple(strides)).split(len(names))]
 
-        for i, (spatial_offset, stride_set) in enumerate(stride_dict.items()):
-            ofs = op.attributes.get("of")
-            assert isa(ofs, StringAttr) or isa(ofs, ArrayAttr[StringAttr])
-            if isinstance(ofs, StringAttr):
-                of = ofs
-            else:
-                of = ofs.data[i]
+        for of, (spatial_offset, stride_set) in zip(names, groups, strict=True):
             hardware_strides = stride_set.strides[:4]
             # Perform software for loop unrolling:
             software_strides = stride_set.strides[4:]
@@ -1343,3 +1338,19 @@ class AIEConvertOfs(ModulePass):
         PatternRewriteWalker(TransferToObjectFIFOPattern()).rewrite_module(op)
         PatternRewriteWalker(RemoveChannels()).rewrite_module(op)
         PatternRewriteWalker(RemoveEmptyCores()).rewrite_module(op)
+        _verify_shim_fifos_are_fed(op)
+
+
+def _verify_shim_fifos_are_fed(module: ModuleOp) -> None:
+    """Fail the build on a shim fifo nothing fills, which would hang on hardware."""
+    shim_rows = {tile.result: tile.row.value.data for tile in module.walk() if isinstance(tile, TileOp)}
+    fed = {task.alloc.string_value() for task in module.walk() if isinstance(task, DmaConfigureTaskForOp)}
+    starved = [
+        fifo.sym_name.data
+        for fifo in module.walk()
+        if isinstance(fifo, ObjectFifoOp) and shim_rows.get(fifo.producerTile) == 0 and fifo.sym_name.data not in fed
+    ]
+    if starved:
+        raise RuntimeError(
+            f"objectfifo(s) produced by a shim tile with no runtime transfer to fill them: {', '.join(sorted(starved))}"
+        )

--- a/stream/opt/allocation/constraint_optimization/context.py
+++ b/stream/opt/allocation/constraint_optimization/context.py
@@ -132,6 +132,18 @@ class NamespaceConstraints:
     ) -> None:
         """Enforce FIFO-depth limits for cores in this namespace."""
 
+    # ---- memory-tile reuse ----
+
+    def add_memory_reuse_constraints(
+        self,
+        model: SolverModel,
+        transfers: list[tuple[Core, LinExpr, LinExpr]],
+    ) -> None:
+        """Narrow how much longer a memory tile may hold a tensor than its reader.
+
+        Each entry is (memory tile, its reuse level, the compute tile's).
+        """
+
     # ---- buffer descriptors ----
 
     def add_buffer_descriptor_constraints(
@@ -203,6 +215,23 @@ class AIE2Constraints(NamespaceConstraints):
             model.add_constr(
                 expr <= core.max_object_fifo_depth,
                 name=f"aie2_obj_fifo_depth_Core_{core.id}",
+            )
+
+    # ---- memory-tile reuse ----
+
+    def add_memory_reuse_constraints(
+        self,
+        model: SolverModel,
+        transfers: list[tuple[Core, LinExpr, LinExpr]],
+    ) -> None:
+        """An AIE memory tile cannot re-send an object it holds, so it may not outlive
+        its reader. Liftable once the object FIFO repeat count is emitted."""
+        for core, mem_level, compute_level in transfers:
+            if not self.applies_to(core):
+                continue
+            model.add_constr(
+                mem_level == compute_level,
+                name=f"aie2_mem_reuse_eq_Core_{core.id}",
             )
 
     # ---- buffer descriptors ----
@@ -277,6 +306,15 @@ class TransferAndTensorContext:
         """Dispatch object-FIFO depth constraints to all namespace strategies."""
         for ns in self.namespace_constraints:
             ns.add_object_fifo_constraints(model, object_fifo_depth)
+
+    def add_memory_reuse_constraints(
+        self,
+        model: SolverModel,
+        transfers: list[tuple[Core, LinExpr, LinExpr]],
+    ) -> None:
+        """Dispatch memory-tile reuse constraints to all namespace strategies."""
+        for ns in self.namespace_constraints:
+            ns.add_memory_reuse_constraints(model, transfers)
 
     def add_buffer_descriptor_constraints(
         self,

--- a/stream/opt/allocation/constraint_optimization/transfer_and_tensor_allocation.py
+++ b/stream/opt/allocation/constraint_optimization/transfer_and_tensor_allocation.py
@@ -43,6 +43,7 @@ from stream.opt.allocation.constraint_optimization.timeslot_allocation import (
 from stream.opt.allocation.constraint_optimization.utils import get_active_latency
 from stream.opt.solver import (
     ConstraintSelection,
+    LinExpr,
     ObjectiveLevel,
     PipeliningModel,
     SolverBackend,
@@ -940,6 +941,8 @@ class TransferAndTensorAllocator:
         memory tile and brought back, so the compute tile owns it until it is complete
         and the memory tile inherits exactly that residency.
         """
+        memory_reuse: list[tuple[Core, LinExpr, LinExpr]] = []
+        namespace_cores = list({c.namespace: c for c in self.mem_cores}.values())
         for tr in self.transfer_nodes:
             inputs = tr.inputs
             outputs = tr.outputs
@@ -963,6 +966,18 @@ class TransferAndTensorAllocator:
                         self._reuse_level_expr(input_tensor) >= self._reuse_level_expr(output_tensor),
                         name=f"reuse_ge_output_{tr.name}",
                     )
+                    # Whether that extra residency is realisable is a target property.
+                    # One core per namespace is enough; the rest repeat the constraint.
+                    memory_reuse.extend(
+                        (
+                            core,
+                            self._reuse_level_expr(input_tensor),
+                            self._reuse_level_expr(output_tensor),
+                        )
+                        for core in namespace_cores
+                    )
+
+        self.context.add_memory_reuse_constraints(self.model, memory_reuse)
 
     def _force_reuse_includes_spatial(self):
         """

--- a/stream/stages/codegen/aie_code_generation.py
+++ b/stream/stages/codegen/aie_code_generation.py
@@ -24,6 +24,7 @@ from stream.compiler.dialects.stream import (
     TransferOp,
     YieldOp,
 )
+from stream.compiler.transforms.aie_add_tracing_script import MAX_TRACED_TILES, AIEAddTracingScript
 from stream.compiler.transforms.aie_convert_ofs import AIEConvertOfs
 from stream.compiler.transforms.aie_dispatch import AIEDispatchPass
 from stream.compiler.transforms.aie_move_tile_ops_up import AIEMoveTileOpsUp
@@ -76,7 +77,12 @@ class AIECodeGenerationStage(Stage):
         self.context.load_dialect(Stream)
         self.context.load_dialect(TSL)
 
-        self.trace_size = self.ctx.get("trace_size", 1048576)
+        # Off unless asked for: tracing adds a trailing runtime sequence argument,
+        # so it changes the calling convention, and its packet flows need routing.
+        self.trace_size = self.ctx.get("trace_size", 0)
+        # Each traced tile needs its own packet route, and a whole-array design has more
+        # cores than the stream switches can carry routes for.
+        self.trace_max_tiles = self.ctx.get("trace_max_tiles", MAX_TRACED_TILES)
         self.npu = self.ctx.get("npu", "npu2")
         self.runtime_args = self.ctx.get("runtime_args", [])
         self.module = None
@@ -396,12 +402,11 @@ class AIECodeGenerationStage(Stage):
             f.write(str(module))
         AIEMoveTileOpsUp().apply(self.context, module)
         ClearMemorySpace().apply(self.context, module)
+        # Before final.mlir is written, since that file is what downstream hosts compile.
+        if self.trace_size:
+            AIEAddTracingScript(trace_size=self.trace_size, max_tiles=self.trace_max_tiles).apply(self.context, module)
         with open(output_path + "/final.mlir", "w") as f:
             f.write(str(module))
-
-        # Optionally, Add Tracing Script
-        # if False:
-        # AIEAddTracingScript(trace_size=trace_size).apply(self.context, module)
 
         self.module = module
 


### PR DESCRIPTION
Codegen has had a tracing pass sitting behind a commented out call for a while, written against an older mlir-aie that needed packet flows built by hand. mlir-aie v1.4.0 has a proper trace dialect, so this rewrites the pass to emit that and turns it back on.

- Emit an `aie.trace` block per traced tile, plus the host config and one start config per block in the runtime sequence.
- Keep tracing off unless asked for. It adds a trailing runtime sequence argument, so it changes the
  calling convention, and its packet flows need routing that a full design may not have spare.
- Let the caller pick which tiles to trace and how many. Routing runs out well before the packet id space does, so tracing every core in a whole array design does not work.
- Drop the round trip through the mlir-aie python bindings. The pass built a throwaway module, printed it, reparsed it and spliced the ops in by position, which broke whenever the printer changed. It now builds the ops directly, so codegen no longer needs those bindings.
- Run the pass before `final.mlir` is written, since that is the file downstream hosts compile.
- Add a short doc comparing the model's predicted cycles against a hardware trace.

Needs the ops from xdslproject/xdsl-aie#28, which has merged. The pin in `stream/aie_setup.py` points at that upstream commit.

Checked with `stream-setup-aie` in a clean venv: the SwiGLU codegen job runs with tracing on and its output parses under the v1.4.0 `aie-opt`. On Strix the traced design produces a decodable trace, and the untraced path is unchanged.
